### PR TITLE
Add auth info to DELETE call

### DIFF
--- a/lib/instances.js
+++ b/lib/instances.js
@@ -36,7 +36,8 @@ const Instances = {
     return new Promise((resolve, reject) => {
       request.delete(
         {
-          url: client.url + '/instances/' + id
+          url: client.url + '/instances/' + id,
+          auth: client.auth
         },
         function(error, response, body) {
           if (error) {


### PR DESCRIPTION
DELETE /instances/{id} call was missing optional auth info, added it. Please merge if you're interested.